### PR TITLE
Move lru_cache definitions to __init__

### DIFF
--- a/dissect/ntfs/index.py
+++ b/dissect/ntfs/index.py
@@ -47,8 +47,6 @@ class Index:
         self.record = record
         self.name = name
 
-        self.index_buffer = lru_cache(128)(self.index_buffer)
-
         self.root = IndexRoot(self, self.record.open(name, ATTRIBUTE_TYPE_CODE.INDEX_ROOT))
 
         if self.record.ntfs and self.record.ntfs.cluster_size <= self.root.bytes_per_index_buffer:
@@ -60,6 +58,8 @@ class Index:
             self._index_stream = self.record.open(self.name, ATTRIBUTE_TYPE_CODE.INDEX_ALLOCATION)
         except FileNotFoundError:
             self._index_stream = None
+
+        self.index_buffer = lru_cache(128)(self.index_buffer)
 
     def __iter__(self) -> Iterator[IndexEntry]:
         return self.entries()

--- a/dissect/ntfs/mft.py
+++ b/dissect/ntfs/mft.py
@@ -46,6 +46,7 @@ class Mft:
     def __init__(self, fh: BinaryIO, ntfs: Optional[NTFS] = None):
         self.fh = fh
         self.ntfs = ntfs
+
         self.get = lru_cache(4096)(self.get)
 
     def __call__(self, ref, *args, **kwargs) -> MftRecord:


### PR DESCRIPTION
Using the lru_cache decorators on class methods, the ones that have a reference to `self`,
will also cache self. So we move it to the __init__ of the class
    
(DIS-2913)