### PR TITLE
Add caching to Secure lookup

### DIFF
--- a/dissect/ntfs/secure.py
+++ b/dissect/ntfs/secure.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 from typing import BinaryIO, Iterator
+from functools import lru_cache
 from uuid import UUID
 
 from dissect.util.sid import read_sid
@@ -24,6 +25,8 @@ class Secure:
         self.record = record
         self.sds = None
         self.sii = None
+
+        self.lookup = lru_cache(4096)(self.lookup)
 
         if record:
             self.sds = record.open("$SDS")

--- a/dissect/ntfs/secure.py
+++ b/dissect/ntfs/secure.py
@@ -40,7 +40,6 @@ class Secure:
             self.sds.size = self.sds.seek(0, io.SEEK_END)
 
         self.lookup = lru_cache(4096)(self.lookup)
-        self._iter_entries = lru_cache(4096)(self._iter_entries)
 
     def _iter_entries(self, offset: int = 0) -> Iterator[c_ntfs._SECURITY_DESCRIPTOR_HEADER]:
         """Iterate over all SDS entries, optionally starting from a specific offset.

--- a/dissect/ntfs/secure.py
+++ b/dissect/ntfs/secure.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import io
-from typing import BinaryIO, Iterator
 from functools import lru_cache
+from typing import BinaryIO, Iterator
 from uuid import UUID
 
 from dissect.util.sid import read_sid
@@ -26,8 +26,6 @@ class Secure:
         self.sds = None
         self.sii = None
 
-        self.lookup = lru_cache(4096)(self.lookup)
-
         if record:
             self.sds = record.open("$SDS")
             self.sii = record.index("$SII")
@@ -40,6 +38,9 @@ class Secure:
         # Hack for file-like objects that don't have a .size attribute
         if not hasattr(self.sds, "size"):
             self.sds.size = self.sds.seek(0, io.SEEK_END)
+
+        self.lookup = lru_cache(4096)(self.lookup)
+        self._iter_entries = lru_cache(4096)(self._iter_entries)
 
     def _iter_entries(self, offset: int = 0) -> Iterator[c_ntfs._SECURITY_DESCRIPTOR_HEADER]:
         """Iterate over all SDS entries, optionally starting from a specific offset.


### PR DESCRIPTION
After having profiled the MFT code it became apparent that the `secure.lookup` inside [`get_owner_and_group`](https://github.com/fox-it/dissect.target/blob/2f218b2539eca86aca54a9aea5188e434906e294/dissect/target/plugins/filesystem/ntfs/utils.py#L72) is the culprit. See image below.

I have compared the following situations:
* Original
* Removing the `get_owner_and_group` call
* Adding `lru_cache` to `self.lookup`
Which yields the following results:

| Situation | Parsing 100.000 records | Parsing 9.206.590 records |
|---|---|---|
| Original | 1m33s | 57m51s |
| Removed | 25s | N/A |
| Cached | 24s | **13m27s** |

Here we can see an improvement of 430% by adding caching.

Steps to create the image:
```
python -m cProfile -o profile.pstats -m dissect.target.tools.query -t ~/Documents/research/dissect/Collection/ -f mft --limit 100000 | rdump -w test.json
gprof2dot -f pstats profile.pstats | dot -Tpng -o image.out
```
![image](https://github.com/fox-it/dissect.ntfs/assets/6420723/5bc9eba0-4c21-4083-b22d-da4916db952b)
